### PR TITLE
Add recipe type selection

### DIFF
--- a/app/src/main/java/yos/develop/recipeapp/core/components/Components.kt
+++ b/app/src/main/java/yos/develop/recipeapp/core/components/Components.kt
@@ -58,6 +58,7 @@ import com.airbnb.lottie.compose.rememberLottieComposition
 import yos.develop.recipeapp.R
 import yos.develop.recipeapp.core.model.RecipeModel
 import yos.develop.recipeapp.core.utils.Constants
+import yos.develop.recipeapp.core.utils.Catalog
 
 @Composable
 fun ButtonGlobal(
@@ -275,6 +276,14 @@ fun ItemRecipe(
             Text(
                 modifier = Modifier.padding(horizontal = 16.dp),
                 text = "${Constants.TIME} ${recipe.preparationTime} min.",
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                style = MaterialTheme.typography.labelSmall
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                modifier = Modifier.padding(horizontal = 16.dp),
+                text = if(recipe.typeRecipe == Catalog.HOT_RECIPE) Constants.HOT_RECIPE_TEXT else Constants.COLD_RECIPE_TEXT,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
                 style = MaterialTheme.typography.labelSmall

--- a/app/src/main/java/yos/develop/recipeapp/core/di/AppModule.kt
+++ b/app/src/main/java/yos/develop/recipeapp/core/di/AppModule.kt
@@ -29,7 +29,9 @@ class AppModule {
     @Singleton
     @Provides
     fun provideAppDatabase(@ApplicationContext appContext: Context): AppDatabase{
-        return Room.databaseBuilder(appContext, AppDatabase::class.java, Constants.TABLE_NAME).build()
+        return Room.databaseBuilder(appContext, AppDatabase::class.java, Constants.TABLE_NAME)
+            .fallbackToDestructiveMigration()
+            .build()
     }
 
     @Singleton

--- a/app/src/main/java/yos/develop/recipeapp/core/model/RecipeModel.kt
+++ b/app/src/main/java/yos/develop/recipeapp/core/model/RecipeModel.kt
@@ -1,10 +1,13 @@
 package yos.develop.recipeapp.core.model
 
+import yos.develop.recipeapp.core.utils.Catalog
+
 data class RecipeModel(
     val idRecipe: Int = 0,
     val title: String = "",
     val description: String = "",
     val preparationTime: Int = 0,
     val favorite: Boolean = false,
-    val routeImage: String? = null
+    val routeImage: String? = null,
+    val typeRecipe: Int = Catalog.HOT_RECIPE
 )

--- a/app/src/main/java/yos/develop/recipeapp/core/room/config/AppDatabase.kt
+++ b/app/src/main/java/yos/develop/recipeapp/core/room/config/AppDatabase.kt
@@ -9,7 +9,7 @@ import yos.develop.recipeapp.core.room.tables.user.UserEntity
 
 @Database(
     entities = [UserEntity::class, RecipeEntity::class],
-    version = 1
+    version = 2
 )
 abstract class AppDatabase: RoomDatabase() {
 

--- a/app/src/main/java/yos/develop/recipeapp/core/room/tables/recipe/RecipeEntity.kt
+++ b/app/src/main/java/yos/develop/recipeapp/core/room/tables/recipe/RecipeEntity.kt
@@ -11,5 +11,6 @@ data class RecipeEntity(
     val description: String,
     val preparationTime: Int,
     val favorite: Boolean,
-    val routeImage: String?
+    val routeImage: String?,
+    val typeRecipe: Int
 )

--- a/app/src/main/java/yos/develop/recipeapp/core/utils/Catalog.kt
+++ b/app/src/main/java/yos/develop/recipeapp/core/utils/Catalog.kt
@@ -8,6 +8,11 @@ object Catalog {
     const val TITLE_TEXT_FIELD = 3
     const val DESCRIPTION_TEXT_FIELD = 4
     const val PREPARATION_TIME_TEXT_FIELD = 5
+    const val TYPE_RECIPE_FIELD = 6
+
+    //Type Recipe
+    const val HOT_RECIPE = 0
+    const val COLD_RECIPE = 1
 
     //recipe
     const val ID_FOR_ADD_RECIPE = 0

--- a/app/src/main/java/yos/develop/recipeapp/core/utils/Constants.kt
+++ b/app/src/main/java/yos/develop/recipeapp/core/utils/Constants.kt
@@ -37,6 +37,9 @@ object Constants {
     const val TITLE_LABEL = "Título"
     const val DESCRIPTION_LABEL = "Descripción"
     const val PREPARATION_TIME_LABEL = "Tiempo de preparación"
+    const val TYPE_RECIPE_LABEL = "Tipo de receta"
+    const val HOT_RECIPE_TEXT = "Caliente"
+    const val COLD_RECIPE_TEXT = "Fría"
 
     //Error message
     const val THIS_EMAIL_DOES_NOT_CORRESPOND_TO_KOALIT_USER = "Este correo no corresponde al usuario de KOALIT"

--- a/app/src/main/java/yos/develop/recipeapp/core/utils/Extensions.kt
+++ b/app/src/main/java/yos/develop/recipeapp/core/utils/Extensions.kt
@@ -20,7 +20,8 @@ fun RecipeEntity.toModel(): RecipeModel{
         description,
         preparationTime,
         favorite,
-        routeImage
+        routeImage,
+        typeRecipe
     )
 }
 
@@ -31,6 +32,7 @@ fun RecipeModel.toEntity(): RecipeEntity{
         description = description,
         preparationTime = preparationTime,
         favorite = favorite,
-        routeImage = routeImage
+        routeImage = routeImage,
+        typeRecipe = typeRecipe
     )
 }

--- a/app/src/main/java/yos/develop/recipeapp/screen/recipe/data/RecipeRepositoryImpl.kt
+++ b/app/src/main/java/yos/develop/recipeapp/screen/recipe/data/RecipeRepositoryImpl.kt
@@ -30,7 +30,7 @@ class RecipeRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun saveFavoriteRecipe(recipe: RecipeModel): Resource<Unit> {
+    override suspend fun updateRecipe(recipe: RecipeModel): Resource<Unit> {
         return try {
             recipeDao.updateRecipe(recipeEntity = recipe.toEntity())
             Resource.Success(Unit)

--- a/app/src/main/java/yos/develop/recipeapp/screen/recipe/domain/RecipeRepository.kt
+++ b/app/src/main/java/yos/develop/recipeapp/screen/recipe/domain/RecipeRepository.kt
@@ -9,5 +9,5 @@ interface RecipeRepository {
 
     suspend fun insertRecipe(recipe: RecipeModel): Resource<Unit>
 
-    suspend fun saveFavoriteRecipe(recipe: RecipeModel): Resource<Unit>
+    suspend fun updateRecipe(recipe: RecipeModel): Resource<Unit>
 }

--- a/app/src/main/java/yos/develop/recipeapp/screen/recipe/ui/RecipeComponents.kt
+++ b/app/src/main/java/yos/develop/recipeapp/screen/recipe/ui/RecipeComponents.kt
@@ -17,6 +17,8 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.FavoriteBorder
@@ -29,12 +31,14 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.RadioButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
@@ -218,6 +222,63 @@ fun BodyRecipe(
 
             }
         )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Text(
+            text = Constants.TYPE_RECIPE_LABEL,
+            style = MaterialTheme.typography.titleLarge,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .selectableGroup(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Row(
+                Modifier
+                    .selectable(
+                        selected = state.typeRecipe == Catalog.HOT_RECIPE,
+                        onClick = { onEvent(RecipeEvent.ChangeTypeRecipe(Catalog.HOT_RECIPE)) },
+                        role = Role.RadioButton
+                    ),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                RadioButton(
+                    selected = state.typeRecipe == Catalog.HOT_RECIPE,
+                    onClick = null
+                )
+                Text(
+                    text = Constants.HOT_RECIPE_TEXT,
+                    modifier = Modifier.padding(start = 4.dp)
+                )
+            }
+
+            Spacer(modifier = Modifier.width(16.dp))
+
+            Row(
+                Modifier
+                    .selectable(
+                        selected = state.typeRecipe == Catalog.COLD_RECIPE,
+                        onClick = { onEvent(RecipeEvent.ChangeTypeRecipe(Catalog.COLD_RECIPE)) },
+                        role = Role.RadioButton
+                    ),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                RadioButton(
+                    selected = state.typeRecipe == Catalog.COLD_RECIPE,
+                    onClick = null
+                )
+                Text(
+                    text = Constants.COLD_RECIPE_TEXT,
+                    modifier = Modifier.padding(start = 4.dp)
+                )
+            }
+        }
 
         Spacer(modifier = Modifier.height(32.dp))
 

--- a/app/src/main/java/yos/develop/recipeapp/screen/recipe/ui/RecipeEvent.kt
+++ b/app/src/main/java/yos/develop/recipeapp/screen/recipe/ui/RecipeEvent.kt
@@ -12,6 +12,8 @@ sealed class RecipeEvent {
 
     data class ChangeInputs(val type: Int, val newValue: String): RecipeEvent()
 
+    data class ChangeTypeRecipe(val type: Int): RecipeEvent()
+
     data object ChangeFavorite: RecipeEvent()
 
     data object SaveRecipe: RecipeEvent()

--- a/app/src/main/java/yos/develop/recipeapp/screen/recipe/ui/RecipeState.kt
+++ b/app/src/main/java/yos/develop/recipeapp/screen/recipe/ui/RecipeState.kt
@@ -2,6 +2,7 @@ package yos.develop.recipeapp.screen.recipe.ui
 
 import android.net.Uri
 import yos.develop.recipeapp.core.model.RecipeModel
+import yos.develop.recipeapp.core.utils.Catalog
 
 data class RecipeState(
     val errorMessage: String = "",
@@ -12,6 +13,7 @@ data class RecipeState(
     val title: String = "",
     val description: String = "",
     val preparationTime: String = "",
+    val typeRecipe: Int = Catalog.HOT_RECIPE,
     val enableButton: Boolean = true,
     val isLoadingSaveRecipe: Boolean = false,
     val routeImage: String = "",

--- a/app/src/main/java/yos/develop/recipeapp/screen/recipe/ui/RecipeViewModel.kt
+++ b/app/src/main/java/yos/develop/recipeapp/screen/recipe/ui/RecipeViewModel.kt
@@ -52,6 +52,9 @@ class RecipeViewModel @Inject constructor(
             is RecipeEvent.ChangeInputs -> {
                 changeInputs(type = event.type, newValue = event.newValue)
             }
+            is RecipeEvent.ChangeTypeRecipe -> {
+                changeTypeRecipe(type = event.type)
+            }
             RecipeEvent.ChangeFavorite -> {
                 changeFavorite()
             }
@@ -69,7 +72,7 @@ class RecipeViewModel @Inject constructor(
             state = state.copy(recipe = state.recipe.copy(favorite = !state.recipe.favorite))
         }else{
             viewModelScope.launch(Dispatchers.IO) {
-                val response = recipeRepository.saveFavoriteRecipe(
+                val response = recipeRepository.updateRecipe(
                     recipe = state.recipe.copy(favorite = !state.recipe.favorite)
                 )
 
@@ -81,6 +84,30 @@ class RecipeViewModel @Inject constructor(
                         }
                         is Resource.Success -> {
                             state = state.copy(recipe = state.recipe.copy(favorite = !state.recipe.favorite))
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun changeTypeRecipe(type: Int){
+        if(state.recipe.idRecipe == Catalog.ID_FOR_ADD_RECIPE){
+            state = state.copy(typeRecipe = type)
+        }else{
+            viewModelScope.launch(Dispatchers.IO) {
+                val response = recipeRepository.updateRecipe(
+                    recipe = state.recipe.copy(typeRecipe = type)
+                )
+
+                withContext(Dispatchers.Main){
+                    when(response){
+                        is Resource.Failure -> {
+                            state = state.copy(errorMessage = response.exception.localizedMessage?:"---")
+                            state = state.copy(isError = true)
+                        }
+                        is Resource.Success -> {
+                            state = state.copy(recipe = state.recipe.copy(typeRecipe = type))
                         }
                     }
                 }
@@ -110,6 +137,7 @@ class RecipeViewModel @Inject constructor(
                                 state = state.copy(imageUri = Uri.parse(response.result.routeImage))
                             }
                             state = state.copy(preparationTime = response.result.preparationTime.toString())
+                            state = state.copy(typeRecipe = response.result.typeRecipe)
                             state = state.copy(isLoadingDataInitial = false)
                         }
                     }
@@ -159,7 +187,8 @@ class RecipeViewModel @Inject constructor(
                         description = state.description,
                         preparationTime = state.preparationTime.toInt(),
                         favorite = state.recipe.favorite,
-                        routeImage = state.routeImage
+                        routeImage = state.routeImage,
+                        typeRecipe = state.typeRecipe
                     )
                 )
 
@@ -263,6 +292,7 @@ class RecipeViewModel @Inject constructor(
         state = state.copy(title = "")
         state = state.copy(description = "")
         state = state.copy(preparationTime = "")
+        state = state.copy(typeRecipe = Catalog.HOT_RECIPE)
         state = state.copy(recipe = RecipeModel())
     }
 }


### PR DESCRIPTION
## Summary
- add `typeRecipe` field for recipes
- allow selecting hot/cold recipe in recipe screen
- persist recipe type in Room and expose via model/entity
- update repository, state and event handling
- bump Room database version and use destructive migration
- show recipe type in recipe list items

## Testing
- `./gradlew test` *(fails: Unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687460d32bc08321a64dc2824d3454aa